### PR TITLE
Add webkit prefix for Safari/iOS

### DIFF
--- a/website/http/portalstyle.css
+++ b/website/http/portalstyle.css
@@ -147,6 +147,7 @@ body {
 /* hide back of pane during swap */
 .front, .back {
 	backface-visibility: hidden;
+	-webkit-backface-visibility: hidden;
 	position: absolute;
 	top: 0;
 	left: 0;


### PR DESCRIPTION
Dunno why the bottom bracket registers as a change, this is just using github's web interface without actually pulling the code. This fixes it for my phone/Safari browsers. There are no more prefixes for this attribute.
